### PR TITLE
Fix azure prod crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "start": "nodemon server.js"
+    "start": "node server.js"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.14.0",


### PR DESCRIPTION
Error is happening because `nodemon `command. Changed to `node`.

[JIRA CG-9](https://comp299-group3.atlassian.net/browse/CG-9?atlOrigin=eyJpIjoiZTg1NGM1MmFjNTM2NDc4ZDg4NGE0MTE3YzAyMzY4ZTIiLCJwIjoiaiJ9)